### PR TITLE
Add setup.py for pypi package, code refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 env
+/.coverage
+/.venv/
+/nosetests.xml
+*.pyc
+/dist/
+/docker_record.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+VENV_DIR = .venv
+VENV_RUN = . $(VENV_DIR)/bin/activate
+
+usage:             ## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+install:           ## Install dependencies
+	(test `which virtualenv` || pip install --user virtualenv || sudo pip install virtualenv)
+	(test -e $(VENV_DIR) || virtualenv $(VENV_DIR))
+	($(VENV_RUN) && pip install --upgrade pip)
+	(test ! -e requirements.txt || ($(VENV_RUN) && pip install -r requirements.txt))
+
+run:               ## Run main application
+	($(VENV_RUN); bin/docker-record $(CONTAINER))
+
+publish:           ## Publish the library to the central PyPi repository
+	# build and upload archive
+	($(VENV_RUN) && ./setup.py sdist upload)
+
+test:              ## Run automated tests
+	make lint && \
+		$(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=docker_record --with-xunit --exclude='$(VENV_DIR).*' .
+
+lint:              ## Run code linter to check code style
+	($(VENV_RUN); pep8 --max-line-length=100 --exclude=$(VENV_DIR),dist .)
+
+clean:             ## Clean up
+	rm -rf dist
+
+.PHONY: usage clean install publish

--- a/bin/docker-record
+++ b/bin/docker-record
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# vim: set ts=4; shiftwidth=4; expandtab
+
+"""docker-record
+
+Usage:
+  docker-record <CONTAINER>
+  docker-record <CONTAINER> --replay
+"""
+import os
+import sys
+
+PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
+    sys.path.insert(0, PARENT_FOLDER)
+
+from docopt import docopt
+from docker_record import main
+
+if __name__ == '__main__':
+
+    arguments = docopt(__doc__, version='docker-record 1.0')
+    container = arguments['<CONTAINER>']
+
+    if arguments['--replay']:
+        main.replay(container)
+    else:
+        main.record(container)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-docopt
-docker-py
+coverage==4.0.3
+docker-py==1.10.6
+docopt==0.6.2
+nose==1.3.7
+pep8==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import re
+import setuptools
+from setuptools import find_packages, setup
+
+install_requires = []
+dependency_links = []
+package_data = {}
+
+with open('requirements.txt') as f:
+    requirements = f.read()
+
+
+for line in re.split('\n', requirements):
+    if line and line[0] == '#' and '#egg=' in line:
+        line = re.search(r'#\s*(.*)', line).group(1)
+    if line and line[0] != '#':
+        install_requires.append(line)
+
+
+package_data = {
+    '': ['Makefile', '*.md', 'requirements.txt']
+}
+
+
+if __name__ == '__main__':
+
+    setup(
+        name='docker-record',
+        version='0.0.3',
+        description='',
+        author='Jürgen Cito, Waldemar Hummer',
+        author_email='cito@ifi.uzh.ch, waldemar.hummer@gmail.com',
+        url='https://github.com/citostyle/docker-record',
+        scripts=['bin/docker-record'],
+        packages=find_packages(exclude=("tests", "tests.*")),
+        package_data=package_data,
+        install_requires=install_requires,
+        dependency_links=dependency_links,
+        test_suite="tests",
+        license="Apache License 2.0",
+        zip_safe=False,
+        classifiers=[
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.6",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.3",
+            "License :: OSI Approved :: Apache Software License"
+        ]
+    )


### PR DESCRIPTION
Code refactoring:
* add setup.py for publishing the pypi package
* use `virtualenv` to install dependencies
* add Makefile targets
* add make target for tests and code linter

The initial package has already been published to pypi, the tool can now be simply installed via:
```
pip install docker-record
```

To release a new version, we can bump the version number in `setup.py` and then run `make publish`.