### PR TITLE
[w.i.p.] Initial version of filesystem diffs per recorded command

### DIFF
--- a/bin/docker-record
+++ b/bin/docker-record
@@ -4,7 +4,7 @@
 """docker-record
 
 Usage:
-  docker-record <CONTAINER>
+  docker-record <CONTAINER_OR_IMAGE>
   docker-record <CONTAINER> --replay
 """
 import os
@@ -20,10 +20,9 @@ from docker_record import main
 if __name__ == '__main__':
 
     arguments = docopt(__doc__, version='docker-record 1.0')
-    container = arguments['<CONTAINER>']
 
     if arguments['--replay']:
-        main.replay(container)
+        main.replay(arguments['<CONTAINER>'])
     else:
-        main.record(container)
+        main.record(arguments['<CONTAINER_OR_IMAGE>'])
 

--- a/docker_record/main.py
+++ b/docker_record/main.py
@@ -1,89 +1,98 @@
-from docker import Client
-import io
 import os
-import sys
-import tarfile
+import time
+import subprocess
+from docker_record.util import docker_util, fs_util, cmd_util, common
+
+# file path constants
+COMMAND_FILEPATH = '%s/cmd' % fs_util.SESSION_DIR
+ENVIRONMENT_FILEPATH = '%s/env' % fs_util.SESSION_DIR
+WORKDIR_FILEPATH = '%s/pwd' % fs_util.SESSION_DIR
+FSDIFF_FILEPATH = '%s/fsdiff' % fs_util.SESSION_DIR
+
+BUILD_CONTEXT_PATH = './build/'
+DOCKER_SOCKET_PATH = '/var/run/docker.sock'
+CONTAINER_BOOTSTRAP_SECS = 5
 
 # record
 
+def record(container_or_image):
 
-def record(container):
+    # run container if the given parameter is an image
+    container = container_or_image
+    if not docker_util.is_running_container(container_or_image):
+        # start container from image
+        cmd = 'docker run -it -d -v {sock}:{sock} -e DOCKER_HOST=unix://{sock} --entrypoint= {img} /bin/sh'
+        result = common.run(cmd.format(sock=DOCKER_SOCKET_PATH, img=container_or_image))
+        container = result.strip()[:12]
+        print('Started container from image %s: %s' % (container_or_image, container))
+        print('Waiting a few moments until container has initialized')
+        time.sleep(CONTAINER_BOOTSTRAP_SECS)
 
     # construct the bash script that will instrument the user's session
     RECORD_TEMPLATE = """bash --init-file <(echo '{instrumentation}')"""
     INSTRUMENTATION = '''
-SESSION_ROOT=/tmp/record;
+SESSION_ROOT=%s;
+CONTAINER_ID=%s;
 mkdir -p $SESSION_ROOT;
 function __instrument() {
   echo $EUID >> $SESSION_ROOT/euid &&
   echo $BASH_COMMAND >> $SESSION_ROOT/cmd &&
   echo $PWD >> $SESSION_ROOT/pwd &&
-  echo $(export | tr "\\n" ";") >> $SESSION_ROOT/env ||
+  echo $(export | tr "\\n" ";") >> $SESSION_ROOT/env &&
+  docker diff $CONTAINER_ID >> $SESSION_ROOT/fsdiff &&
+  echo "%s" >> $SESSION_ROOT/fsdiff &&
+  true ||
   exit;
 };
+docker diff $CONTAINER_ID >> $SESSION_ROOT/fsdiff; echo "%s" >> $SESSION_ROOT/fsdiff;
 shopt -s extdebug;
-trap __instrument DEBUG;'''
+trap __instrument DEBUG;''' % (fs_util.SESSION_DIR, container, fs_util.FSDIFF_DELIMITER, fs_util.FSDIFF_INIT_DELIMITER)
     RECORD_COMMAND = RECORD_TEMPLATE.format(instrumentation=INSTRUMENTATION.replace('\n', ' '))
 
     # use docker exec to drop the user into an instrumented bash session
     os.execlp('docker', 'docker', 'exec', '-ti', container, 'bash', '-c', RECORD_COMMAND)
 
+
 # replay
-
-# make it work now, refactor later
-SESSION_PATH = '/tmp/record/{filename}'
-COMMAND_FILENAME = 'cmd'
-ENVIRONMENT_FILENAME = 'env'
-WORKDIR_FILENAME = 'pwd'
-
-BUILD_CONTEXT_PATH = './build/'
-
-# these commands from the history should not be included in the Dockerfile
-# list has to be extended, for now there are just common setup/maintenance commands
-COMMAND_BLACKLIST = ['ls', 'cd', 'pwd', 'history', 'du', 'top', 'ps',
-                     'exit', 'clear', 'git status', 'cat']
-
-# Heuristic: these commands are likely to be "service"
-DOCKER_CMD_WHITELIST = ['service', '/etc/init.d/']
-
-# Heuristic: add files that were opened by an editor and correspond to docker diff
-EDITOR_WHITELIST = ['nano', 'vim', 'emacs', 'joe']
-
 
 def replay(container):
 
-    commands = read_session(container, COMMAND_FILENAME)
-    environments = read_session(container, ENVIRONMENT_FILENAME)
-    workdirs = read_session(container, WORKDIR_FILENAME)
+    commands = read_session(container, COMMAND_FILEPATH)
+    environments = read_session(container, ENVIRONMENT_FILEPATH)
+    workdirs = read_session(container, WORKDIR_FILEPATH)
+    fschanges = fs_util.get_file_changes_per_command(container, FSDIFF_FILEPATH)
+    # make sure we have the same array lengths
+    fschanges = fschanges[-len(commands):]
 
     dockerfile = []
     dockerfile_cmd_command = ""
 
-    fs_changes = filesystem_diff(container)
+    fs_changes = docker_util.filesystem_diff(container)
 
     # Extract RUN and CMD directives from our history logs into the Dockerfile
-    for command, environment, workdir in zip(commands, environments, workdirs):
+    for command, environment, workdir, fschange in zip(commands, environments, workdirs, fschanges):
 
-        if is_blacklisted(command):
+        if cmd_util.is_blacklisted(command):
             continue
 
-        if is_docker_cmd(command):
+        if cmd_util.is_docker_cmd(command):
             # there can only be one, and this current heuristic
             # just picks the last that has been executed
             dockerfile_cmd_command = "CMD " + command
-        elif is_editor(command):
+        elif cmd_util.is_editor(command):
             # now check whether the file was actually created/changed in the FS
-            changed_path = extract_path_from_editor_command(command).replace('\n', '')
-            if changed_in_filesystem(fs_changes, changed_path):
+            changed_path = cmd_util.extract_path_from_editor_command(command).replace('\n', '')
+            if fs_util.changed_in_filesystem(fs_changes, changed_path):
                 if changed_path.startswith('/'):
                     source_path = changed_path
                 else:
                     source_path = workdir + "/" + changed_path
 
                 destination_path = BUILD_CONTEXT_PATH + flatten_path(source_path)
-                copy_from_container(container, source_path, destination_path)
+                docker_util.copy_from_container(container, source_path, destination_path)
                 dockerfile.append("ADD " + destination_path + " " + source_path)
         else:
+            dockerfile.append("# creates filesystem changes: %s" % fschange.values())
             dockerfile.append("RUN " + command)
 
     dockerfile.append(dockerfile_cmd_command)
@@ -92,69 +101,9 @@ def replay(container):
         print instruction
 
 
-def copy_from_container(container, source, destination):
-    file_contents = copy(container, source)
-    with open(destination, 'w') as f:
-        f.write(file_contents)
-
-
 def flatten_path(path):
     return path.replace('/', '_')
 
 
-def changed_in_filesystem(fs_changes, filename):
-    # ignore the Kind parameter for now
-    for change_paths in fs_changes.keys():
-        if filename == change_paths:
-            return True
-    return False
-
-
-def filesystem_diff(container):
-    client = Client()
-    raw_changes = client.diff(container)
-    changes = {}
-    for raw_change in raw_changes:
-        changes[raw_change['Path']] = raw_change['Kind']
-    return changes
-
-
-def extract_path_from_editor_command(command):
-    return command.split(' ')[1]
-
-
-def read_session(container, filename):
-    return copy(container, SESSION_PATH.format(filename=filename)).split("\n")
-
-
-def is_docker_cmd(command):
-    return startswith(command, DOCKER_CMD_WHITELIST)
-
-
-def is_editor(command):
-    return startswith(command, EDITOR_WHITELIST)
-
-
-def is_blacklisted(command):
-    if not command.strip():
-        return True
-
-    return startswith(command, COMMAND_BLACKLIST)
-
-
-def startswith(string, collection):
-    for item in collection:
-        if string.startswith(item):
-            return True
-    return False
-
-
-def copy(container, path):
-    client = Client()
-    response = client.copy(container, path)
-    buffer = io.BytesIO()
-    buffer.write(response.data)
-    buffer.seek(0)
-    tar = tarfile.open(fileobj=buffer, mode='r')
-    for member in tar.getmembers():
-        return tar.extractfile(member).read()
+def read_session(container, filepath):
+    return docker_util.copy(container, filepath).strip().split("\n")

--- a/docker_record/util/cmd_util.py
+++ b/docker_record/util/cmd_util.py
@@ -1,0 +1,37 @@
+
+# these commands from the history should not be included in the Dockerfile
+# list has to be extended, for now there are just common setup/maintenance commands
+COMMAND_BLACKLIST = ['ls', 'cd', 'pwd', 'history', 'du', 'top', 'ps',
+                     'exit', 'clear', 'git status', 'cat']
+
+# Heuristic: these commands are likely to be "service"
+DOCKER_CMD_WHITELIST = ['service', '/etc/init.d/']
+
+# Heuristic: add files that were opened by an editor and correspond to docker diff
+EDITOR_WHITELIST = ['nano', 'vim', 'emacs', 'joe']
+
+
+def startswith(string, collection):
+    for item in collection:
+        if string.startswith(item):
+            return True
+    return False
+
+
+def is_docker_cmd(command):
+    return startswith(command, DOCKER_CMD_WHITELIST)
+
+
+def is_editor(command):
+    return startswith(command, EDITOR_WHITELIST)
+
+
+def is_blacklisted(command):
+    if not command.strip():
+        return True
+
+    return startswith(command, COMMAND_BLACKLIST)
+
+
+def extract_path_from_editor_command(command):
+    return command.split(' ')[1]

--- a/docker_record/util/common.py
+++ b/docker_record/util/common.py
@@ -1,0 +1,4 @@
+import subprocess
+
+def run(cmd):
+    return subprocess.check_output(cmd, shell=True)

--- a/docker_record/util/docker_util.py
+++ b/docker_record/util/docker_util.py
@@ -1,0 +1,39 @@
+import io
+import tarfile
+from docker import Client
+
+
+def is_running_container(id):
+    docker_client = Client()
+    containers = docker_client.containers()
+    for container in containers:
+        if container['Id'].startswith(id):
+            return True
+    return False
+
+
+def copy_from_container(container, source, destination):
+    file_contents = copy(container, source)
+    with open(destination, 'w') as f:
+        f.write(file_contents)
+
+
+def filesystem_diff(container):
+    client = Client()
+    raw_changes = client.diff(container)
+    changes = {}
+    for raw_change in raw_changes:
+        changes[raw_change['Path']] = raw_change['Kind']
+    return changes
+
+
+def copy(container, path):
+    client = Client()
+    # client.copy(..) is deprecated, use client.get_archive(..) instead
+    stream, status = client.get_archive(container, path)
+    buffer = io.BytesIO()
+    buffer.write(stream.read())
+    buffer.seek(0)
+    tar = tarfile.open(fileobj=buffer, mode='r')
+    for member in tar.getmembers():
+        return tar.extractfile(member).read()

--- a/docker_record/util/fs_util.py
+++ b/docker_record/util/fs_util.py
@@ -1,0 +1,67 @@
+from docker_record.util import docker_util
+
+FSDIFF_INIT_DELIMITER = '---init-delimiter---'
+FSDIFF_DELIMITER = '---cmd-delimiter---'
+
+SESSION_DIR = '/tmp/record'
+
+
+class FileChange(object):
+    def __init__(self, line):
+        self.line = line
+        self.action = line[0]
+        self.file = line[2:]
+
+    def __str__(self):
+        return self.line
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        return self.line == other.line
+
+    @classmethod
+    def parse_changes(cls, change_lines):
+        result = {}
+        for line in change_lines:
+            line = line.strip()
+            if line:
+                change = FileChange(line)
+                if not change.file.startswith(SESSION_DIR):
+                    result[change.file] = change
+        return result
+
+    @classmethod
+    def diff(cls, old_changes, new_changes):
+        result = {}
+        for key, val in new_changes.iteritems():
+            old_val = old_changes.get(key)
+            if not old_val or not old_val.__eq__(val):
+                result[key] = val
+        return result
+
+
+def get_file_changes_per_command(container, filepath):
+    file_content = docker_util.copy(container, filepath)
+    parts = file_content.split(FSDIFF_INIT_DELIMITER)
+    result = []
+
+    changes = FileChange.parse_changes(parts[0].split('\n'))
+    parts = parts[1].split(FSDIFF_DELIMITER)
+
+    for i in range(0, len(parts)):
+        part = parts[i]
+        new_changes = FileChange.parse_changes(part.split('\n'))
+        change_diff = FileChange.diff(changes, new_changes)
+        result.append(change_diff)
+        changes.update(change_diff)
+    return result
+
+
+def changed_in_filesystem(fs_changes, filename):
+    # ignore the Kind parameter for now
+    for change_paths in fs_changes.keys():
+        if filename == change_paths:
+            return True
+    return False


### PR DESCRIPTION
**Note: This is work in progress. Not ready for merging yet (see last paragraph of this comment)**

This PR adds a simplistic per-command file system change tracker.

* The CLI is slightly extended such that either a running container or an image can be specified (`docker-record <CONTAINER_OR_IMAGE>`). If an image is specified, a container is automatically started in the background with the required volume mounts (required to execute `docker` commands from within the container)

* File changes are tracked via simple `docker diff` commands, the intermediate states are stored to `/tmp/record/fsdiff` inside the container. Since `docker diff` always returns the full list of file changes since the container was started, we compute the diff of changes to obtain a list of file changes for each individual command.

* Example:
```
$ bin/docker-record <some_image>
Started container from image <some_image>: a999ea2ecd9a
Waiting a few moments until container has initialized
bash# touch /tmp/foo1
bash# ls /tmp/foo1
/tmp/foo1
bash# touch /tmp/foo2
bash# exit
$ bin/docker-record a999ea2ecd9a --replay
# creates filesystem changes: [A /tmp/foo1]
RUN touch /tmp/foo1
# creates filesystem changes: [A /tmp/foo2]
RUN touch /tmp/foo2
```

There are still a few limitations, though:

* Piped commands (e.g., `echo "foo" > /tmp/bar` or `ps aux | grep foo`) are not handled as a single command, but as individual commands. This appears to be an issue with the bash init-file instrumentation, we need to fix it.

* If the same file, say `/tmp/foobar` is changed by two consecutive commands, we would only record that there has been a change from the first command. In order to fix this, we need to store modification timestamps and/or MD5 hashes of file states.

* The code currently assumes that the "docker" binary/command is available in the container. That is generally not the case and we need to find a smart way to install `docker` CLI into the container if it is not available (mounting is not an option, because of binary incompatibility between MacOS on the host and Linux in the container).

In particular the last limitation is problematic. Currently, it may break the functionality of docker-record if the `docker` command is not available in the container. Therefore, I am not in favor of merging this now, but rather find a solution first before merging to master.